### PR TITLE
Retain full function call in partition from dataform in some cases.

### DIFF
--- a/src/dataform.js
+++ b/src/dataform.js
@@ -16,7 +16,11 @@ export const parsePartitionBy = (value) => {
   if (trunc) {
     const [, dataType, field, granularity] = trunc
     return {
-      field,
+      // dbt passes through date type / day granularity fields unmodified, see #9
+      field:
+        dataType.toLowerCase() === 'date' && granularity.toLowerCase() === 'day'
+          ? value
+          : field,
       data_type: dataType.toLowerCase(),
       granularity: granularity.toLowerCase(),
     }
@@ -24,7 +28,7 @@ export const parsePartitionBy = (value) => {
 
   // e.g. DATE(<date_column>)
   const date = value.match(/^date\(([^)]+)\)$/i)
-  if (date) return { field: date[1], data_type: 'date', granularity: 'day' }
+  if (date) return { field: value, data_type: 'date', granularity: 'day' }
 
   // e.g. RANGE_BUCKET(<integer_column>, GENERATE_ARRAY(0, 1000000, 1000))
   const int = value.match(

--- a/src/dataform.test.js
+++ b/src/dataform.test.js
@@ -4,7 +4,7 @@ describe('parsePartitionBy()', () => {
   it.each([
     [
       'DATE(some_field)',
-      { field: 'some_field', data_type: 'date', granularity: 'day' },
+      { field: 'DATE(some_field)', data_type: 'date', granularity: 'day' },
     ],
     [
       'DATETIME_TRUNC(some_field, HOUR)',


### PR DESCRIPTION
DBT passes through the field spec as is when the data type is date and the granularity is day, so these need to be passed through as is.
