### PR TITLE
Improve inconsistent handling of dirs vs schemas.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -134,7 +134,8 @@ await Promise.all([
     await tablesToDbtModels(configs, adjustName)
   ).map(async ({ directory, models }) => {
     const dir = path.resolve(DBT_MODELS_DIR, directory)
-    return writeFile(dir, `_${directory}__models.yml`, models)
+    const prefix = directory ? `_${directory}_` : ''
+    return writeFile(dir, `${prefix}_models.yml`, models)
   }),
 ])
 


### PR DESCRIPTION
Now uses the schema consistently for the schema tag and the directory
consistently for the location to write to.

Also corrects the handling of models directly in the dataform
definitions directory, by

* ensuring that the models yml is written there without an extra prefix
* writing the models there not in a definitions/ subdirectory
