### PR TITLE
Improved schema rewriting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A tool to assist in migrating from [Dataform](https://dataform.co/) to [DBT](htt
 - View materialisations are set per model, with the assumption that the default will be tables.
 - BigQuery clustering config is migrated; see "what might work" for info on partitioning.
 - Tags are migrated.
+- Projects using multiple schemas automatically have appropriate macros set up to rewrite these appropriately when not writing to the `prod` target (written to the target dataset - use environment variables to set this in `profiles.yml` on a per-developer basis, `direnv` recommended - with the original schema name prepended, e.g. `developer_schema.original_schema__original_table`).
 
 ## What might work
 

--- a/src/dbt.js
+++ b/src/dbt.js
@@ -42,6 +42,31 @@ const GENERATE_SCHEMA_NAME = `
 {% macro generate_schema_name(custom_schema_name, node) -%}
     {{ generate_schema_name_for_env(custom_schema_name, node) }}
 {%- endmacro %}
+
+{# Prefix non-production tables with their schema #}
+{% macro generate_alias_name(custom_alias_name=none, node=none) -%}
+    {# Default handling to calculate table name #}
+    {%- if custom_alias_name is none -%}
+        {%- set node_name = node.name -%}
+    {%- else -%}
+        {%- set node_name = custom_alias_name | trim -%}
+    {%- endif -%}
+
+    {%- if target.name == 'prod' -%}
+        {# No prefix for prod #}
+        {{ node_name }}
+    {%- else -%}
+        {#- Get the custom schema name -#}
+        {%- set schema = node.unrendered_config.schema | trim %}
+
+        {#- Highlight missing schemas, _ prefix to sort early -#}
+        {%- if not schema -%}
+            {%- set schema = '_NO_SCHEMA' %}
+        {%- endif -%}
+
+        {{ schema ~ "__" ~ node_name }}
+    {%- endif -%}
+{%- endmacro %}
 `.trim()
 
 export const writeGenerateSchemaName = async (root) =>


### PR DESCRIPTION
It's better to rewrite model names, not just schema names, so that it's easy to see in which schema models will be placed in prod.
